### PR TITLE
Release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All changes made on any release of this project should be commented on high leve
 Document model based on [Semantic Versioning](http://semver.org/).
 Examples of how to use this _markdown_ cand be found here [Keep a CHANGELOG](http://keepachangelog.com/).
 
-## Unreleased
+## [0.3.0](https://github.com/stone-payments/kong-plugin-template-transformer/tree/v0.3.0) - 2018-05-17
 ### Fixed
 - Stops relying on content-type header and tries to parse the response from the API, returning bad request if not possible
 - Passes body to the request table as a table, not string

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You can run `luacov` and it will generate a `luacov.report.out` containing a com
 ## lint
 
 `make lint` or `luacheck -q .` in the plugin folder should run the linter.
+
 # credits
 
 made with :heart: by Stone Payments

--- a/template-transformer/template-transformer-0.3.0-0.rockspec
+++ b/template-transformer/template-transformer-0.3.0-0.rockspec
@@ -1,5 +1,5 @@
 package = "template-transformer"
-version = "0.2.2-0"
+version = "0.3.0-0"
 source = {
    url = "https://github.com/stone-payments/kong-plugin-template-transformer",
 }


### PR DESCRIPTION
## [0.3.0](https://github.com/stone-payments/kong-plugin-template-transformer/tree/v0.3.0) - 2018-05-17
### Fixed
- Stops relying on content-type header and tries to parse the response from the API, returning bad request if not possible
- Passes body to the request table as a table, not string
