### PR TITLE
[develop] Release/v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All changes made on any release of this project should be commented on high leve
 Document model based on [Semantic Versioning](http://semver.org/).
 Examples of how to use this _markdown_ cand be found here [Keep a CHANGELOG](http://keepachangelog.com/).
 
-## Unreleased
+## [0.6.0](https://github.com/stone-payments/kong-plugin-template-transformer/tree/v0.6.0) - 2018-08-28
 ### Added
 - Configuration variable hide fields and not log them.
 

--- a/template-transformer/kong-plugin-template-transformer-0.6.0-0.rockspec
+++ b/template-transformer/kong-plugin-template-transformer-0.6.0-0.rockspec
@@ -1,5 +1,5 @@
 package = "kong-plugin-template-transformer"
-version = "0.5.0-0"
+version = "0.6.0-0"
 source = {
    url = "https://github.com/stone-payments/kong-plugin-template-transformer",
 }


### PR DESCRIPTION
## Description
- Adds configuration variable hide fields and not log them.

## How Has This Been Tested?
`make test`
`sudo make install && sudo kong restart -vv`
- Configure the plugin like this:

```json
{
    "hidden_fields": [
        "Password",
        "token"
    ]
}
```
- Execute authenticate request and see the logs.