### PR TITLE
Release: v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All changes made on any release of this project should be commented on high leve
 Document model based on [Semantic Versioning](http://semver.org/).
 Examples of how to use this _markdown_ cand be found here [Keep a CHANGELOG](http://keepachangelog.com/).
 
-## Unreleased
-- Add Travis for Continuous Integration
+## [0.8.0] (https://github.com/stone-payments/kong-plugin-template-transformer/tree/v0.8.0) - 2018-10-30
+- Add Travis for CI/CD
 
 ## [0.7.2](https://github.com/stone-payments/kong-plugin-template-transformer/tree/v0.7.2) - 2018-10-10
 ### Fixed

--- a/template-transformer/kong-plugin-template-transformer-0.8.0-0.rockspec
+++ b/template-transformer/kong-plugin-template-transformer-0.8.0-0.rockspec
@@ -1,5 +1,5 @@
 package = "kong-plugin-template-transformer"
-version = "0.7.2-0"
+version = "0.8.0-0"
 source = {
    url = "https://github.com/stone-payments/kong-plugin-template-transformer",
 }


### PR DESCRIPTION
## [0.8.0] (https://github.com/stone-payments/kong-plugin-template-transformer/tree/v0.8.0) - 2018-10-30
- Add Travis for CI/CD