### PR TITLE
Support kong 1.0+ with updated schema and removal of kong.dao.errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get install -y \
   luarocks \
   git \
   libssl1.0-dev \
-  make
+  make \
+  m4
 
 ADD Makefile .
 RUN make setup

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DEV_ROCKS = "lua-cjson 2.1.0" "kong 0.13.1" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0" "lua-resty-template 1.9-1" "--server=http://luarocks.org/dev luaffi scm-1"
+DEV_ROCKS = "lua-cjson 2.1.0" "kong 1.0.3" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0" "lua-resty-template 1.9-1" "--server=http://luarocks.org/dev luaffi scm-1"
 PROJECT_FOLDER = template-transformer
 LUA_PROJECT = kong-plugin-template-transformer
 

--- a/template-transformer/spec/handler_spec.lua
+++ b/template-transformer/spec/handler_spec.lua
@@ -19,6 +19,7 @@ local ngx =  {
     },
     header = mock_ngx_headers,
     config = {
+        subsystem = "http",
         prefix = spy.new(function()
             return "mock"
         end)

--- a/template-transformer/spec/schema_spec.lua
+++ b/template-transformer/spec/schema_spec.lua
@@ -21,6 +21,7 @@ describe("TestSchema", function()
       local fields = schema.fields[3].config.fields;
 
       assert.are_same(typedefs.no_consumer, schema.fields[1].consumer)
+      assert.are_same(typedefs.run_on_first, schema.fields[2].run_on)
       assert.not_nil(fields[1].request_template)
       assert.not_nil(fields[1].request_template.type, "string")
       assert.not_nil(fields[1].request_template.required, false)

--- a/template-transformer/spec/schema_spec.lua
+++ b/template-transformer/spec/schema_spec.lua
@@ -14,22 +14,29 @@ local ngx =  {
 _G.ngx = ngx
 
 local schema = require('schema')
+local typedefs = require "kong.db.schema.typedefs"
 
 describe("TestSchema", function()
     it("should initialize schema correctly", function()
-      assert.is_true(schema.no_consumer)
-      assert.not_nil(schema.fields.request_template)
-      assert.not_nil(schema.fields.request_template.type, "string")
-      assert.not_nil(schema.fields.request_template.required, false)
-      assert.not_nil(schema.fields.response_template)
-      assert.not_nil(schema.fields.request_template.type, "string")
-      assert.not_nil(schema.fields.request_template.required, false)
+      local fields = schema.fields[3].config.fields;
+
+      assert.are_same(typedefs.no_consumer, schema.fields[1].consumer)
+      assert.not_nil(fields[1].request_template)
+      assert.not_nil(fields[1].request_template.type, "string")
+      assert.not_nil(fields[1].request_template.required, false)
+      assert.not_nil(fields[2].response_template)
+      assert.not_nil(fields[2].response_template.type, "string")
+      assert.not_nil(fields[2].response_template.required, false)
+      assert.not_nil(fields[3].hidden_fields)
+      assert.not_nil(fields[3].hidden_fields.type, "array")
+      assert.not_nil(fields[3].hidden_fields.required, false)
+      assert.not_nil(fields[3].hidden_fields.elements.type, "string")
     end)
 
     it("should return false then the request template is invalid", function()
       local string_template = "hello im a wrong {{a['}} template"
 
-      local valid = schema.self_check(nil, { request_template = string_template }, nil, nil)
+      local valid = schema.fields[3].config.custom_validator({ request_template = string_template })
 
       assert.is_false(valid)
     end)
@@ -37,7 +44,7 @@ describe("TestSchema", function()
     it("should return true then the request template is valid", function()
       local string_template = "hello im a correct {{a}} template"
 
-      local valid = schema.self_check(nil, { request_template = string_template }, nil, nil)
+      local valid = schema.fields[3].config.custom_validator({ request_template = string_template })
 
       assert.is_true(valid)
     end)
@@ -45,7 +52,7 @@ describe("TestSchema", function()
     it("should return false then the response template is invalid", function()
       local string_template = "hello im a wrong {{a['}} template"
 
-      local valid = schema.self_check(nil, { response_template = string_template }, nil, nil)
+      local valid = schema.fields[3].config.custom_validator({ request_template = string_template })
 
       assert.is_false(valid)
     end)
@@ -53,7 +60,7 @@ describe("TestSchema", function()
     it("should return true then the response template is valid", function()
       local string_template = "hello im a correct {{a}} template"
 
-      local valid = schema.self_check(nil, { response_template = string_template }, nil, nil)
+      local valid = schema.fields[3].config.custom_validator({ request_template = string_template })
 
       assert.is_true(valid)
     end)


### PR DESCRIPTION
## Description

Migrated from the legacy plugin schema.
Remove the use of `kong.dao.errors`, which has been removed from kong.

Kong 0.14 and earlier will no longer be supported.
Kong does have a `convert_legacy_schema` function that will convert old schemas when it detects them.
So if we leave out the schema update and only remove the use of `kong.dao.errors` we can maintain support for <= 0.14.
If this is something you'd prefer, let me know and I'll make another merge request.

## How Has This Been Tested?

I've built, installed and manually tested the modified plugin on the following docker images:

kong/1.1rc2-centos :heavy_check_mark:
kong/1.0-centos :heavy_check_mark:
kong/0.15-centos :heavy_check_mark:
kong/0.14-centos :negative_squared_cross_mark:

As well as passing the preexisting unit tests (with updates as necessary).

## Checklist

