### PR TITLE
Remove use of kong.dao.errors so that the plugin can work on 1.0.0+ in a backwards compatible manner.

### DIFF
--- a/template-transformer/schema.lua
+++ b/template-transformer/schema.lua
@@ -1,5 +1,4 @@
 local template = require 'resty.template'
-local Errors = require "kong.dao.errors"
 
 function check_template(schema, config, dao, is_updating)
   if config.request_template then
@@ -8,7 +7,7 @@ function check_template(schema, config, dao, is_updating)
     end)
 
     if status ~= true then
-      return false, Errors.schema(err)
+      return false, err
     end
 
     return status, err
@@ -20,7 +19,7 @@ function check_template(schema, config, dao, is_updating)
     end)
 
     if status ~= true then
-      return false, Errors.schema(err)
+      return false, err
     end
 
     return status, err


### PR DESCRIPTION
## Description
See #77 

This merge request includes the removal of `kong.dao.errors`, but not the updated plugin schema.
This allows the plugin to remain functional in all previously supported kong versions and also support 1.0.0+.

There are caveats however.

By not updating the schema we are relying on the [convert_legacy_schema](https://github.com/Kong/kong/blob/bc48efeabc5d7460271d09d20e8e95b1b2e97a04/kong/db/schema/plugin_loader.lua#L37) function for support in 0.15.0+.
`convert_legacy_schema` doesn't convert the self_check function, so request/response template validation will not function in kong 0.15.0+ (all templates are admitted).
Template validation works as usual in <0.15.0 (only valid templates are admitted).

Additionally, by removing the use of `kong.dao.errors`, errors returned by the self_check function are no longer handled well by kong <0.15.0 and don't forward the message to the client.

The end result for requests adding the plugin with an invalid template is this:

kong <0.15.0 (failure, but no message):
```
$ http post localhost:8001/routes/02a4fe27-704d-4c67-bc59-1f778dd5dca2/plugins name="kong-plugin-template-transformer" config.request_template="{% for a b v %}"
HTTP/1.1 400 Bad Request
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 3
Content-Type: application/json; charset=utf-8
Date: Sun, 31 Mar 2019 05:10:18 GMT
Server: kong/0.14.1

{}
```

kong >=0.15.0 (success with invalid template):
```
$ http post localhost:8001/routes/02a4fe27-704d-4c67-bc59-1f778dd5dca2/plugins name="kong-plugin-template-transformer" config:='{"request_template":"{% for a b v %}"}'
HTTP/1.1 201 Created
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 334
Content-Type: application/json; charset=utf-8
Date: Sun, 31 Mar 2019 05:17:13 GMT
Server: kong/0.15.0

{
    "api": null,
    "config": {
        "hidden_fields": null,
        "request_template": "{% for a b v %}",
        "response_template": null
    },
    "consumer": null,
    "created_at": 1554009432,
    "enabled": true,
    "id": "9e71eff5-868b-42e8-b07c-8f8b8a5ca030",
    "name": "kong-plugin-template-transformer",
    "route": {
        "id": "02a4fe27-704d-4c67-bc59-1f778dd5dca2"
    },
    "run_on": "first",
    "service": null
}
```

Regardless, I wish to use this plugin with kong 1+ and I think this is the best temporary solution to support both pre and post 0.15.0 short of maintaining two versions of the plugin.
Hopefully the changes in this MR are aceptable until it's okay to merge #77 for full 1+ support.

## How Has This Been Tested?
Manually tested with all major versions >= 0.14 with results described above.
Preexisting unit tests.

## Checklist