### PR TITLE
feat: Add request query string to the response template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-## backend-chp codeowners
-* @PFadel @leoferlopes @biancarosa @italomarcel @julianasglasser @diegolucasb @andremacdowell
+* @andremacdowell @EclesioMeloJunior @jeancabral @jonathanlazaro1 @leoferlopes @PFadel

--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -162,7 +162,7 @@ function TemplateTransformerHandler:body_filter(config)
         if body == nil then
           return ngx.ERROR
         end
-        local query_string = req_get_uri_args()
+        local req_query_string = req_get_uri_args()
         local transformed_body = template_transformer.get_template(config.response_template){headers = headers,
                                                                                              body = body,
                                                                                              raw_body = raw_body,
@@ -170,7 +170,7 @@ function TemplateTransformerHandler:body_filter(config)
                                                                                              cjson_decode = cjson_decode,
                                                                                              mask_field = utils.mask_field,
                                                                                              status = ngx.status,
-                                                                                             query_string = query_string}
+                                                                                             req_query_string = req_query_string}
         
         
         transformed_body = prepare_body(transformed_body)

--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -162,13 +162,15 @@ function TemplateTransformerHandler:body_filter(config)
         if body == nil then
           return ngx.ERROR
         end
+        local query_string = req_get_uri_args()
         local transformed_body = template_transformer.get_template(config.response_template){headers = headers,
                                                                                              body = body,
                                                                                              raw_body = raw_body,
                                                                                              cjson_encode = cjson_encode,
                                                                                              cjson_decode = cjson_decode,
                                                                                              mask_field = utils.mask_field,
-                                                                                             status = ngx.status}
+                                                                                             status = ngx.status,
+                                                                                             query_string = query_string}
         
         
         transformed_body = prepare_body(transformed_body)


### PR DESCRIPTION
## Description
The query string from the request is currently accessible only to the request template itself. This PR intents to make it accessible to the response template, too.

## How Has This Been Tested?
I installed the modified version of the plugin on my computer and called kong requests that make use of the query string on the response template. They worked fine.
I also confirmed that the same requests stopped working when the unmodified template transformer plugin was installed.