### PR TITLE
fix(BC#3345299796): Template transformer should preserve empty arrays

### DIFF
--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -1,6 +1,8 @@
 local BasePlugin = require 'kong.plugins.base_plugin'
-local cjson_decode = require('cjson').decode
-local cjson_encode = require('cjson').encode
+local cjson = require('cjson.safe').new()
+cjson.decode_array_with_array_mt(true)
+local cjson_decode = cjson.decode
+local cjson_encode = cjson.encode
 
 local req_set_body_data = ngx.req.set_body_data
 local req_get_body_data = ngx.req.get_body_data

--- a/template-transformer/spec/handler_spec.lua
+++ b/template-transformer/spec/handler_spec.lua
@@ -231,6 +231,16 @@ describe("Test TemplateTransformerHandler body_filter", function()
     assert.equal(config.response_template, ngx.arg[1])
   end)
 
+  it("should preserve empty arrays", function()
+    TemplateTransformerHandler:new()
+    local config = {
+      response_template = "{ \"data\": {{ cjson_encode(body) }} }"
+  }
+  _G.ngx.ctx.buffer = '{"p2":"v1", "a":[]}'
+  TemplateTransformerHandler:body_filter(config)
+  assert.equal('{ "data": {"p2":"v1","a":[]} }', ngx.arg[1])
+  end)
+
   it("should set first ngx arg to template when using raw_body in the template", function()
     TemplateTransformerHandler:new()
     local config = {


### PR DESCRIPTION
## Description
This PR fixes a bug where template transformer doesn't preserve empty JSON arrays, when encoding objects with `cjson_encode` (it converts the array to an empty object).
A fix to this problem [was already available](https://github.com/Kong/kong/commit/e364354db438b22be1af20f6fb2ce4f8fefd41bf) on kong's response transformer, so in fact we just brought their solution here.

## How Has This Been Tested?
A test case was written to verify that a JSON body containing an empty array won't be transformed into an empty object.
Also, below are prints showing kong dealing with an empty array, before and after the fix.
![detailInstructions is an empty array, but it was being converted to an empty object](https://user-images.githubusercontent.com/9416565/103947968-56f22080-510f-11eb-8d10-9c13f5b479ff.png)
detailInstructions is an empty array, but it is being converted to an empty object

![detailInstructions after the fix](https://user-images.githubusercontent.com/9416565/103948124-a46e8d80-510f-11eb-8979-421a7a0bbfc1.png)
detailInstructions after the fix