### PR TITLE
Fix/Update lua-cjson version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master, develop]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: debian-stretch
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Update package lists and install necessary build/test systemwide deps
+      - name: Update apt sources/Install system-wide deps
+        run: |
+          apt-get update
+          apt-get install -y lua5.1 liblua5.1-0-dev luarocks git libssl1.0-dev make
+
+      # Runs the tests
+      - name: Setup project deps/Install package
+        run: |
+          make setup
+          make install
+
+      - name: Run tests
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: debian-stretch
+  test:
+    runs-on: ubuntu-latest
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -17,14 +17,18 @@ jobs:
       # Update package lists and install necessary build/test systemwide deps
       - name: Update apt sources/Install system-wide deps
         run: |
-          apt-get update
-          apt-get install -y lua5.1 liblua5.1-0-dev luarocks git libssl1.0-dev make
+          sudo apt-get update
+          sudo apt-get install -y lua5.1 liblua5.1-0-dev luarocks git make
 
-      # Runs the tests
-      - name: Setup project deps/Install package
+      - name: Setup project deps
+        run: sudo make setup
+
+      - name: Download and install kong
         run: |
-          make setup
-          make install
+          wget -c https://bintray.com/kong/kong-community-edition-deb/download_file?file_path=dists%2Fkong-community-edition-0.13.1.xenial.all.deb -O kong.deb
+          sudo apt-get install ./kong.deb
 
-      - name: Run tests
-        run: make test
+      - name: Install package/Execute tests
+        run: |
+          sudo make install
+          make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI-0.13.1
 
 on:
   pull_request:
@@ -23,7 +23,7 @@ jobs:
       - name: Setup project deps
         run: sudo make setup
 
-      - name: Download and install kong
+      - name: Download and install kong Community Edition 0.13.1
         run: |
           wget -c https://bintray.com/kong/kong-community-edition-deb/download_file?file_path=dists%2Fkong-community-edition-0.13.1.xenial.all.deb -O kong.deb
           sudo apt-get install ./kong.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM debian:stretch
 RUN apt-get update
 
 RUN apt-get install -y \
-  lua5.2 \
-  liblua5.2-dev \
+  lua5.1 \
+  liblua5.1-0-dev \
   luarocks \
   git \
   libssl1.0-dev \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DEV_ROCKS = "lua-cjson 2.1.0" "kong 0.13.1" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0" "lua-resty-template 1.9-1" "--server=http://luarocks.org/dev luaffi scm-1"
+DEV_ROCKS = "https://raw.githubusercontent.com/openresty/lua-cjson/2.1.0.8/lua-cjson-2.1.0.6-1.rockspec" "kong 0.13.1" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0" "lua-resty-template 1.9-1" "--server=http://luarocks.org/dev luaffi scm-1"
 PROJECT_FOLDER = template-transformer
 LUA_PROJECT = kong-plugin-template-transformer
 


### PR DESCRIPTION
## Description
After the release #122 , we noticed that lua-cjson dependency was in a version that didn't allow us to use the code changes we made. This was caused by a misalignment between our local environment and the packaging one, were our local environment already had lua-cjson in an updated version. This PR intents to solve this problem.
Also, we are adding a CI step on GitHub to try and prevent something like that to happen again.
## How Has This Been Tested?
We changed the lua-cjson dep version and ran tests on Docker env (which is as close as we can get from Travis env).