### PR TITLE
Allow for non-json request bodies

### DIFF
--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -90,7 +90,7 @@ function TemplateTransformerHandler:access(config)
     local string_body = req_get_body_data()
     if string_body then
       raw_body = prepare_body(string_body)
-      body = cjson_decode(raw_body)
+      body = read_json_body(string_body)
     end
 
     local headers = req_get_headers()


### PR DESCRIPTION
## Description
Currently if you make a request to an endpoint with this plugin enabled and the request body isn't json (e.g. xml), then an error is produced by cjson_decode and the request is aborted.

This PR allows the json parsing of the input body to fail, in which case the 'body' template variable will be nil and the 'raw_body' template variable will still contain the unparsed raw request body,

## How Has This Been Tested?
I've tested this by deploying the modified plugin code and trying out various request body types using curl.
Previously I would get a 500 response with `{"message":"An unexpected error occurred"}` for all non json requests.
After this change my template would be successfully rendered and forwarded to the application.