### PR TITLE
fix: Set content length header name

### DIFF
--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -105,7 +105,7 @@ function TemplateTransformerHandler:access(config)
     transformed_body = prepare_body(transformed_body)
 
     req_set_body_data(transformed_body)
-    req_set_header(CONTENT_LENGTH, #transformed_body)
+    req_set_header("Content-Length", #transformed_body)
 
     if transformed_body ~= "" then
       local json_transformed_body = cjson_decode(transformed_body)


### PR DESCRIPTION
content-length header name was being set as `CONTENT_LENGTH` which was causing errors since the function `ngx.req.set_header` expects a string with the header name and a value for it. Fixed by changing it to a string literal.