### PR TITLE
[develop] Release/v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.0.1](https://github.com/stone-payments/kong-plugin-template-transformer/compare/v1.0.0...v1.0.1) (2021-12-21)
+
+
+### Bug Fixes
+
+* Fix set content-length header.
+
 ## [1.0.0](https://github.com/stone-payments/kong-plugin-template-transformer/compare/v0.17.1...v1.0.0) (2021-12-21)
 
 

--- a/kong-plugin-template-transformer-1.0.1-0.rockspec
+++ b/kong-plugin-template-transformer-1.0.1-0.rockspec
@@ -1,5 +1,5 @@
 package = "kong-plugin-template-transformer"
-version = "1.0.0-0"
+version = "1.0.1-0"
 source = {
    url = "git://github.com/stone-payments/kong-plugin-template-transformer",
 }


### PR DESCRIPTION
content-length header name was being set as CONTENT_LENGTH which was causing errors since the function ngx.req.set_header expects a string with the header name and a value for it. Fixed by changing it to a string literal.