### PR TITLE
Add route_groups to response template

### DIFF
--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -160,6 +160,7 @@ function TemplateTransformerHandler:body_filter(config)
           return ngx.ERROR
         end
         local req_query_string = req_get_uri_args()
+        local router_matches = ngx.ctx.router_matches
         local transformed_body = template_transformer.get_template(config.response_template){headers = headers,
                                                                                              body = body,
                                                                                              raw_body = raw_body,
@@ -167,7 +168,8 @@ function TemplateTransformerHandler:body_filter(config)
                                                                                              cjson_decode = cjson_decode,
                                                                                              mask_field = utils.mask_field,
                                                                                              status = ngx.status,
-                                                                                             req_query_string = req_query_string}
+                                                                                             req_query_string = req_query_string,
+                                                                                             route_groups = router_matches.uri_captures}
         
         
         transformed_body = prepare_body(transformed_body)

--- a/template-transformer/spec/handler_spec.lua
+++ b/template-transformer/spec/handler_spec.lua
@@ -223,6 +223,15 @@ describe("Test TemplateTransformerHandler body_filter", function()
     assert.equal("{ \"wrapper\": { \"name\": \"fred\" } }", ngx.arg[1])
   end)
 
+  it("should set first ngx arg to template when using route_groups in the template", function()
+    local config = {
+      response_template = "{ \"foo\": \"{{route_groups['group_one']}}\" }"
+    }
+    _G.ngx.ctx.buffer = '{ "name": "fred" }'
+    TemplateTransformerHandler:body_filter(config)
+    assert.equal("{ \"foo\": \"test_match\" }", ngx.arg[1])
+  end)
+
   it("Should return string with bars", function()
     local userName = cjson_encode('im a string with \\bar')
     local config = {


### PR DESCRIPTION
## Description
The route_groups from the request is currently accessible only to the request template. This PR makes it accessible to the response template. Solves #156

## How Has This Been Tested?
Added a test to `handler_spec.lua`. Tested locally with a mock api and Kong 2.8.0