### PR TITLE
feat: Adds ability to bypass when proxy cache plugin has a hit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @andremacdowell @brennogb @glauberatanaka @guih50 @henrique1996n1 @jonathanlazaro1 @leoferlopes @mauriciokb @Wuerike
+* @ALTbruno @andremacdowell @brennogb @glauberatanaka @guih50 @henrique1996n1 @jonathanlazaro1 @leoferlopes @mauriciokb @Miltonrdj @Wuerike

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
 ## Description
 
 ## How Has This Been Tested?
-
-## Checklist

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:22.04
 
 RUN apt update -y && apt install -y lua5.1 liblua5.1-dev build-essential wget git zip unzip
 RUN git config --global url.https://github.com/.insteadOf git://github.com/
-RUN wget https://download.konghq.com/gateway-3.x-ubuntu-bionic/pool/all/k/kong/kong_3.0.0_amd64.deb &&\
-  apt install -y ./kong_3.0.0_amd64.deb
+RUN wget https://download.konghq.com/gateway-3.x-ubuntu-bionic/pool/all/k/kong/kong_3.0.2_amd64.deb &&\
+  apt install -y ./kong_3.0.2_amd64.deb
 
 
 RUN wget https://luarocks.org/releases/luarocks-3.3.1.tar.gz &&\
@@ -13,9 +13,5 @@ RUN wget https://luarocks.org/releases/luarocks-3.3.1.tar.gz &&\
   make && make install
 
 WORKDIR /home/plugin
-
-COPY Makefile .
-COPY rockspec.template .
-RUN make setup
 
 RUN chmod -R a+rw /home/plugin

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DEV_ROCKS = "https://raw.githubusercontent.com/openresty/lua-cjson/2.1.0.8/lua-cjson-2.1.0.6-1.rockspec" "kong 3.0.0" "luacov 0.12.0" "busted 2.0.0-1" "luacov-cobertura 0.2-1" "luacheck 0.20.0" "lua-resty-template 1.9-1"
+DEV_ROCKS = "lua-cjson 2.1.0.10-1" "kong 3.0.2" "luacov 0.12.0" "busted 2.0.0-1" "luacov-cobertura 0.2-1" "luacheck 0.20.0" "lua-resty-template 1.9-1"
 PROJECT_FOLDER = template-transformer
 LUA_PROJECT = kong-plugin-template-transformer
 VERSION = 1.2.0-0

--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -28,7 +28,7 @@ function read_json_body(body)
     body = gsub(body, [[\\]], [[&__escaped__bar;]])
     body = gsub(body, [[\\\r\\\n]], [[&__escaped__eof;]])
     body = gsub(body, [[\\\r]], [[&__escaped__carriage;]])
-    ngx.log(ngx.ERR, body)
+    ngx.log(ngx.DEBUG, body)
     local status, res = pcall(cjson_decode, body)
 
     if status then

--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -10,7 +10,6 @@ local req_set_header = ngx.req.set_header
 local req_get_headers = ngx.req.get_headers
 local req_read_body = ngx.req.read_body
 local res_get_headers = ngx.resp.get_headers
-local table_concat = table.concat
 local sub = string.sub
 local gsub = string.gsub
 local gmatch = string.gmatch
@@ -136,6 +135,14 @@ end
 
 function TemplateTransformerHandler:body_filter(config)
   if config.response_template and config.response_template ~= "" then
+
+    local cache_response = kong.ctx.shared.proxy_cache_hit
+    if cache_response ~= nil then
+      -- No need to do anything. Cache response is already transformed.
+        kong.log.debug("Cache response raw body :: ", cache_response.res.body)
+        return
+    end
+
     local chunk, eof = ngx.arg[1], ngx.arg[2]
     if not eof then
       -- sometimes the data comes in chunks and every chunk is a different call


### PR DESCRIPTION
## Description
This PR adds the possibility of reading cached responses coming from Kong's [proxy-cache](https://docs.konghq.com/hub/kong-inc/proxy-cache/) plugin.

Since the proxy-cache plugin executes with a lower priority than ours, it caches our already transformed responses when the two are present in a route and a cache miss occurs. Also, when there's a cache hit, the proxy-cache plugin sets the response body before the `body_filter` phase, which means we really don't need to do anything in this case.

## How Has This Been Tested?

In this first request, we can see that kong did reach the upstream API, transforming its response (the original property is `foo`, not `transformed_foo`).

![image](https://user-images.githubusercontent.com/9416565/209582671-74adb066-3211-4e40-b6c6-3521f006c5b1.png)

Also we can see that we have two cache headers: one indicating the cache key, and other indicating that we had a cache miss.

![image](https://user-images.githubusercontent.com/9416565/209582758-c87ae375-633a-4be9-8686-fa27cff75224.png)

Next, we made a bunch of requests to kong and it is noticeable that:
* subsequent request times are significantly shorter than the first request
* the upstream still shows only that first call we made
* the response body is still transformed

![image](https://user-images.githubusercontent.com/9416565/209582911-90961ec0-b515-4514-b0cb-c92261aeb86e.png)

Also, we can see two cache headers: the same cache key from the first call and the indication that we had a cache hit.

![image](https://user-images.githubusercontent.com/9416565/209583142-195b7a3d-83c7-4b1b-9711-79da74cc4217.png)
