### PR TITLE
feat: Adds Makefile entry to generate rockspec file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ALTbruno @andremacdowell @brennogb @glauberatanaka @guih50 @henrique1996n1 @jonathanlazaro1 @leoferlopes @mauriciokb @Miltonrdj @Wuerike
+* @andremacdowell @leoferlopes @stone-payments/payments-core-api-gtw

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@ PROJECT_FOLDER = template-transformer
 LUA_PROJECT = kong-plugin-template-transformer
 VERSION = 1.3.0-0
 
-setup:
+rockspec:
 	cp rockspec.template kong-plugin-template-transformer-$(VERSION).rockspec
+
+setup: rockspec
 	@for rock in $(DEV_ROCKS) ; do \
 		if luarocks list --porcelain $$rock | grep -q "installed" ; then \
 			echo $$rock already installed, skipping ; \


### PR DESCRIPTION
## Description
This PR simply adds a Makefile entry for generate the rockspec file directly (this was a duty of the `setup` entry previously).

## How Has This Been Tested?
Given that:
- the `setup` entry still needs to create the rockspec file
-  `setup` is now calling the new `rockspec` entry itself
- the `setup` entry is called during CI

, a simply CI run is enough evidence that everything is working after this change.