### PR TITLE
feat!: Disables templating when response comes from kong itself

### DIFF
--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -137,6 +137,11 @@ end
 function TemplateTransformerHandler:body_filter(config)
   if config.response_template and config.response_template ~= "" then
 
+    if kong.response.get_source() ~= "service" then
+      kong.log.debug("Response is from kong itself or an error ocurred. Not applying any transformations.")
+      return
+    end
+    
     local cache_response = kong.ctx.shared.proxy_cache_hit
     if cache_response ~= nil then
       -- No need to do anything. Cache response is already transformed.

--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -171,7 +171,7 @@ function TemplateTransformerHandler:body_filter(config)
       if gmatch(content_type, "(application/json)")() then
         body = read_json_body(raw_body)
         if body == nil then
-          return ngx.ERROR
+          return kong.response.error(ngx.HTTP_INTERNAL_SERVER_ERROR)
         end
         local req_query_string = req_get_uri_args()
         local router_matches = ngx.ctx.router_matches

--- a/template-transformer/spec/handler_spec.lua
+++ b/template-transformer/spec/handler_spec.lua
@@ -15,6 +15,11 @@ local kong = {
     shared = {
       proxy_cache_hit = nil
     }
+  },
+  response = {
+    get_source = function ()
+      return "service"
+    end
   }
 }
 
@@ -197,6 +202,22 @@ describe("Test TemplateTransformerHandler body_filter", function()
     TemplateTransformerHandler:body_filter(config)
     assert.spy(ngx.resp.get_headers).was_not_called()
     assert.equal('{ "key" : "value" }', ngx.arg[1])
+  end)
+
+  it("should not run when response source is not service", function()
+    local config = {
+      response_template = "{ \"template\": 123 }"
+    }
+    local old_get_source = kong.response.get_source
+    kong.response.get_source = function ()
+      return "exit"
+    end
+
+    TemplateTransformerHandler:body_filter(config)
+    assert.spy(ngx.resp.get_headers).was_not_called()
+    assert.equal('{ "key" : "value" }', ngx.arg[1])
+
+    kong.response.get_source = old_get_source
   end)
 
   it("should not run when there is a cached response", function()


### PR DESCRIPTION
## Description
This PR disables transforming when response is from kong or an error occurred during the request to the upstream, since there's no guarantee that the response body will comply with the template in this case (or even if its content is JSON). This can be determined by using the method `kong.response.get_source` [included in the PDK](https://docs.konghq.com/gateway/3.4.x/plugin-development/pdk/kong.response/#kongresponseget_source).

We're also replacing a call to `ngx.error` to `kong.response.error` in order to not abruptly interrupt the plugin execution chain.

## How Has This Been Tested?
Requests where made where forcefully `kong.response.exit` would be executed, and it was confirmed that the plugin did not apply response transformations.
![image](https://github.com/stone-payments/kong-plugin-template-transformer/assets/9416565/fe3f26f7-c123-4557-ae12-20cc0e0f6d6c)
