### PR TITLE
fix: Makes encoding always transform empty tables into arrays

### DIFF
--- a/template-transformer/handler.lua
+++ b/template-transformer/handler.lua
@@ -1,5 +1,6 @@
 local cjson = require('cjson.safe').new()
 cjson.decode_array_with_array_mt(true)
+cjson.encode_empty_table_as_object(false)
 local cjson_decode = cjson.decode
 local cjson_encode = cjson.encode
 


### PR DESCRIPTION
## Description
This PR adds the flag `encode_empty_table_as_object` with the value `false`, in order to ensure that empty Lua tables will always be transformed into empty JSON arrays when using `cjson.encode`.

## How Has This Been Tested?
I made a request where the previous version of the plugin was enabled and confirmed that the problem was occurring:
![image](https://github.com/stone-payments/kong-plugin-template-transformer/assets/9416565/c7d9f25b-2526-44c1-8b02-7ffdbb1792c4)

Then I applied this version of the plugin and made the same request again. This time, empty arrays were correctly preserved:
![image](https://github.com/stone-payments/kong-plugin-template-transformer/assets/9416565/c2f25d7a-8e9b-4776-a39e-a4696f41c4b6)
