### PR TITLE
fix: Install JSON library for LuaRocks upload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y luarocks
+          sudo luarocks install dkjson
           luarocks upload kong-plugin-template-transformer-*.rockspec --api-key=${{ secrets.LUAROCKS_API_KEY }}
 
       - name: Check if remote release branch exists


### PR DESCRIPTION
## Description

O step `Publish to LuaRocks` (adicionado em #188) falhou no release 3.2.0 com:

```
Sending kong-plugin-template-transformer-3.2.0-1.rockspec ...
Error: A JSON library is required for this command. Failed loading 'cjson', 'dkjson', and 'json'.
```

**Causa raiz:** o `luarocks upload` usa a API HTTP do luarocks.org e precisa de uma biblioteca JSON para serializar a requisição. O pacote `luarocks` do apt não traz nenhuma. No fluxo antigo (`publish.yml`) isso vinha de carona no `make setup`, que instalava `lua-cjson` via `DEV_ROCKS` — perdido quando o step foi enxugado para só o `luarocks upload`.

**Correção:** instalar `dkjson` (Lua puro, sem etapa de compilação) antes do upload:

```yaml
sudo luarocks install dkjson
```

> Observação: o `luasec` (necessário para o HTTPS) já é instalado automaticamente como dependência do pacote `luarocks` do apt, então não precisa ser adicionado.

## How Has This Been Tested?

- Validação de sintaxe YAML do `release-please.yml`.
- Erro reproduzido e confirmado nos logs do run que falhou (release 3.2.0); `dkjson` resolve exatamente a dependência reportada (`cjson/dkjson/json`).
- Mudança restrita ao workflow de CI (sem alteração no código Lua do plugin).

> ⚠️ Nota de operação: o release **3.2.0** já foi criado e seu `.rock` subiu para os artefatos do GitHub, mas a publicação no LuaRocks falhou e **não re-tenta automaticamente** (o `release_created` só é `true` no momento do merge do PR de release). Após este merge, a 3.2.0 precisa ser publicada manualmente no LuaRocks (ou via um próximo release).